### PR TITLE
 为hasRenderableSchema补充对allOf/oneOf/anyOf的检测

### DIFF
--- a/apps/web-ele/src/components/schema-view.vue
+++ b/apps/web-ele/src/components/schema-view.vue
@@ -36,6 +36,10 @@ const variantState = ref<Record<string, number>>({});
 const mode = computed(() => props.mode);
 const rootPath = computed(() => props.pathPrefix || '$');
 
+const requiredLabel = computed(() => {
+  return mode.value === 'response' ? '必含' : '必填';
+});
+
 const hasHtmlDescription = (desc?: string) => Boolean(desc?.includes('<'));
 
 const formatValue = (value: unknown) => {
@@ -556,8 +560,11 @@ const showSchemaStack = computed(() => {
               <span
                 v-if="isRequired(resolvedRootObjectSchema, String(key), value)"
                 class="schema-item__required-tag"
+                :class="{
+                  'schema-item__required-tag--response': mode === 'response',
+                }"
               >
-                必填
+                {{ requiredLabel }}
               </span>
               <div
                 v-if="getPlainDescription(value, getNodePath(String(key)))"
@@ -1163,6 +1170,20 @@ const showSchemaStack = computed(() => {
   border: 1px solid
     color-mix(in srgb, var(--el-color-danger-light-7) 86%, transparent);
   border-radius: 6px;
+}
+
+.schema-item__required-tag--response {
+  color: var(--el-color-info);
+  background: color-mix(
+    in srgb,
+    var(--el-color-info-light-9) 88%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--el-color-info-light-7) 86%,
+    transparent
+  );
 }
 
 .schema-item__type {

--- a/apps/web-ele/src/utils/schema.ts
+++ b/apps/web-ele/src/utils/schema.ts
@@ -441,7 +441,10 @@ export function hasRenderableSchema(schema: any) {
       schema.format ||
       schema.example !== undefined ||
       (Array.isArray(schema.examples) && schema.examples.length > 0) ||
-      schema.default !== undefined,
+      schema.default !== undefined  ||
+      (Array.isArray(schema.allOf) && schema.allOf.length > 0) ||
+      (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) ||
+      (Array.isArray(schema.anyOf) && schema.anyOf.length > 0),
   );
 }
 


### PR DESCRIPTION
修复无法识别包含allOf、oneOf、anyOf数组的可渲染schema的问题

## 📌 描述

<!-- 请简要描述本次 PR 的内容和动机。。 -->

## ✅ 变更类型

请打勾说明你的 PR 类型：

- ✅ 🐞 Bug 修复
- [ ] ✨ 新功能
- [ ] 🛠️ 代码重构/优化

## 🔄 相关 Issue

如果有，请关联 Issue（e.g. `Closes #123`）。

## 🧪 测试情况

请说明你是如何验证这个改动的：

- [ ] 本地构建通过
- ✅ 手动测试了主要功能
- [ ] 添加/更新了测试用例

## 📸 截图（如有）

如果是 UI 改动，请提供截图。
